### PR TITLE
ADD: ThreadPoolExecutorWithReturnValue, full error stack in knowledge. CHANGE:  qwen model max token to the newest

### DIFF
--- a/agentuniverse/agent/action/knowledge/knowledge.py
+++ b/agentuniverse/agent/action/knowledge/knowledge.py
@@ -7,6 +7,7 @@
 # @FileName: knowledge.py
 import os
 import re
+import traceback
 from typing import Optional, Dict, List, Any
 from concurrent.futures import ThreadPoolExecutor, wait, ALL_COMPLETED
 
@@ -163,6 +164,7 @@ class Knowledge(ComponentBase):
             try:
                 future.result()
             except Exception as e:
+                traceback.print_exc()
                 LOGGER.error(f"Exception occurred in knowledge insert: {e}")
         LOGGER.info("Knowledge insert complete.")
 
@@ -188,6 +190,7 @@ class Knowledge(ComponentBase):
             try:
                 future.result()
             except Exception as e:
+                traceback.print_exc()
                 LOGGER.error(f"Exception occurred in knowledge update: {e}")
         LOGGER.info("Knowledge update complete.")
 
@@ -219,6 +222,7 @@ class Knowledge(ComponentBase):
                     if _doc.id not in retrieved_docs:
                         retrieved_docs[_doc.id] = _doc
             except Exception as e:
+                traceback.print_exc()
                 LOGGER.error(f"Exception occurred in knowledge query: {e}")
         retrieved_docs = list(retrieved_docs.values())
         retrieved_docs = self._rag_post_process(retrieved_docs, query)

--- a/agentuniverse/agent_serve/web/thread_with_result.py
+++ b/agentuniverse/agent_serve/web/thread_with_result.py
@@ -74,7 +74,7 @@ class ThreadPoolExecutorWithReturnValue(ThreadPoolExecutor):
         if num_threads < self._max_workers:
             thread_name = '%s_%d' % (self._thread_name_prefix or self,
                                      num_threads)
-            t = threading.Thread(name=thread_name, target=_worker,
+            t = ThreadWithReturnValue(name=thread_name, target=_worker,
                                  args=(weakref.ref(self, weakref_cb),
                                        self._work_queue,
                                        self._initializer,

--- a/agentuniverse/agent_serve/web/thread_with_result.py
+++ b/agentuniverse/agent_serve/web/thread_with_result.py
@@ -6,7 +6,10 @@
 # @Email   : fanen.lhy@antgroup.com
 # @FileName: thread_with_result.py
 
+import threading
 from threading import Thread
+import weakref
+from concurrent.futures.thread import ThreadPoolExecutor, _worker, _threads_queues
 
 from agentuniverse.base.context.framework_context_manager import FrameworkContextManager
 
@@ -54,3 +57,28 @@ class ThreadWithReturnValue(Thread):
         if self.error is not None:
             raise self.error
         return self._return
+
+
+class ThreadPoolExecutorWithReturnValue(ThreadPoolExecutor):
+    def _adjust_thread_count(self):
+        # if idle threads are available, don't spin new threads
+        if self._idle_semaphore.acquire(timeout=0):
+            return
+
+        # When the executor gets lost, the weakref callback will wake up
+        # the worker threads.
+        def weakref_cb(_, q=self._work_queue):
+            q.put(None)
+
+        num_threads = len(self._threads)
+        if num_threads < self._max_workers:
+            thread_name = '%s_%d' % (self._thread_name_prefix or self,
+                                     num_threads)
+            t = threading.Thread(name=thread_name, target=_worker,
+                                 args=(weakref.ref(self, weakref_cb),
+                                       self._work_queue,
+                                       self._initializer,
+                                       self._initargs))
+            t.start()
+            self._threads.add(t)
+            _threads_queues[t] = self._work_queue

--- a/agentuniverse/llm/default/qwen_openai_style_llm.py
+++ b/agentuniverse/llm/default/qwen_openai_style_llm.py
@@ -16,13 +16,13 @@ from agentuniverse.llm.llm_output import LLMOutput
 from agentuniverse.llm.openai_style_llm import OpenAIStyleLLM
 
 QWen_Max_CONTEXT_LENGTH = {
-    "qwen-turbo": 6000,
-    "qwen-plus": 300000,
-    "qwen-max": 6000,
-    "qwen-max-0428": 6000,
-    "qwen-max-0403": 6000,
-    "qwen-max-0107": 6000,
-    "qwen-max-longcontext": 28000
+    "qwen-turbo": 131072,
+    "qwen-plus": 131072,
+    "qwen-max": 32768,
+    "qwen-max-0428": 8000,
+    "qwen-max-0403": 8000,
+    "qwen-max-0107": 8000,
+    "qwen-long": 10000000
 }
 
 


### PR DESCRIPTION
ADD: ThreadPoolExecutorWithReturnValue, a ThreadPoolExecutor which can keep FrameworkContext

ADD: thread in insert_knowledge and query will print full error stack now

CHANGE: change the qwen model max token to the newest