### PR TITLE
FIX: jina ai module path bug CHANGE: move retry annotation int arxiv_tool to annotation path CHANGE: DoubaoEmbedding read env variable ARK_ENDPOINT_ID instead of ENDPOINT_ID

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/doubao_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/doubao_embedding.py
@@ -21,7 +21,7 @@ class DoubaoEmbedding(Embedding):
     ark_api_key: Optional[str] = Field(
         default_factory=lambda: get_from_env("ARK_API_KEY"))
     endpoint_id: Optional[str] = Field(
-        default_factory=lambda: get_from_env("ENDPOINT_ID"))
+        default_factory=lambda: get_from_env("ARK_ENDPOINT_ID"))
     client: Optional[Any] = None
     embedding_dims: Optional[int] = None
 

--- a/agentuniverse/agent/action/tool/arxiv_tool.py
+++ b/agentuniverse/agent/action/tool/arxiv_tool.py
@@ -10,8 +10,8 @@ import os
 from dataclasses import dataclass
 from enum import Enum
 from pydantic import Field
-from agentuniverse.agent.action.tool.utils import retry
 from agentuniverse.agent.action.tool.tool import Tool, ToolInput
+from agentuniverse.base.annotation.retry import retry
 
 
 class SearchMode(Enum):

--- a/agentuniverse/agent/action/tool/utils/__init__.py
+++ b/agentuniverse/agent/action/tool/utils/__init__.py
@@ -1,6 +1,2 @@
 # !/usr/bin/env python3
 # -*- coding:utf-8 -*-
-
-from .retry import retry
-
-__all__ = ['retry']

--- a/agentuniverse/base/annotation/retry.py
+++ b/agentuniverse/base/annotation/retry.py
@@ -1,6 +1,11 @@
 # !/usr/bin/env python3
 # -*- coding:utf-8 -*-
 
+# @Time    : 2025/2/28 17:46
+# @Author  : fanen.lhy
+# @Email   : fanen.lhy@antgroup.com
+# @FileName: retry.py
+
 import functools
 import time
 from typing import Any, Callable
@@ -19,7 +24,7 @@ def retry(max_retries: int = 3, delay: float = 1.0) -> Callable:
                     last_exception = e
                     retries += 1
                     if retries < max_retries:
-                        time.sleep(delay)                    
+                        time.sleep(delay)
             raise Exception(f"Failed after {max_retries} retries. Last error: {str(last_exception)}")
         return wrapper
     return decorator

--- a/examples/sample_standard_app/intelligence/agentic/tool/samples/jina_ai_tool.yaml
+++ b/examples/sample_standard_app/intelligence/agentic/tool/samples/jina_ai_tool.yaml
@@ -4,5 +4,5 @@ tool_type: api
 input_keys: [input]
 metadata:
   type: TOOL
-  module: firework_knowledgebase.intelligence.agentic.tool.jina_ai_tool
+  module: sample_standard_app.intelligence.agentic.tool.jina_ai_tool
   class: JinaAITool


### PR DESCRIPTION
FIX: jina ai module path bug
CHANGE: move retry annotation int arxiv_tool to annotation path
CHANGE: DoubaoEmbedding read env variable ARK_ENDPOINT_ID instead of ENDPOINT_ID