### PR TITLE
Fix: Initialize GeminiEmbedding client

### DIFF
--- a/agentuniverse/agent/action/knowledge/embedding/gemini_embedding.py
+++ b/agentuniverse/agent/action/knowledge/embedding/gemini_embedding.py
@@ -8,6 +8,7 @@ from typing_extensions import Optional
 
 from agentuniverse.agent.action.knowledge.embedding.embedding import Embedding
 from agentuniverse.base.util.env_util import get_from_env
+from agentuniverse.base.config.component_configer.component_configer import ComponentConfiger
 
 
 # @Time : 2025/2/13 12:10
@@ -21,20 +22,19 @@ class GeminiEmbedding(Embedding):
     client: Any = None
     gemini_api_key: Optional[str] = Field(default_factory=lambda: get_from_env("GOOGLE_API_KEY"))
 
-    def __init__(self, **kwargs):
-        try:
-            from google import genai
-        except ImportError as e:
-            raise ImportError(
-                "genai is required. Install with: pip install google-genai"
-            ) from e
-
-        super().__init__(**kwargs)
-        self.client = genai.Client(api_key=self.gemini_api_key)
-        # Gemini does not have a native proxy solution.
-
     def get_embeddings(self, texts: List[str], **kwargs) -> List[List[float]]:
         """Get embeddings for a list of texts using the Gemini API."""
+        if not self.client:
+            if not self.gemini_api_key:
+                raise ValueError("GOOGLE_API_KEY is required but not set")
+            try:
+                from google import genai
+                self.client = genai.Client(api_key=self.gemini_api_key)
+            except ImportError as e:
+                raise ImportError(
+                    "genai is required. Install with: pip install google-genai"
+                ) from e
+            
         model_name = self.embedding_model_name or "text-embedding-004"  # default model
 
         try:
@@ -79,3 +79,22 @@ class GeminiEmbedding(Embedding):
                 return self.gemini_embedding.get_embeddings([text])[0]
 
         return GeminiLangchainEmbedding(gemini_embedding=self)  # Pass the instance of GeminiEmbedding
+
+
+    def _initialize_by_component_configer(self, embedding_configer: ComponentConfiger) -> 'Embedding':
+        super()._initialize_by_component_configer(embedding_configer)
+        if hasattr(embedding_configer, "gemini_api_key"):
+            self.gemini_api_key = embedding_configer.gemini_api_key
+        
+        # Initialize client if API key is available
+        if self.gemini_api_key:
+            try:
+                from google import genai
+                self.client = genai.Client(api_key=self.gemini_api_key)
+            except ImportError as e:
+                raise ImportError(
+                    "genai is required. Install with: pip install google-genai"
+                ) from e
+            except Exception as e:
+                raise ValueError(f"Failed to initialize Gemini client: {str(e)}")
+        return self


### PR DESCRIPTION
# Fix: Initialize GeminiEmbedding client in _initialize_by_component_configer method

## Description
Fixed an issue in GeminiEmbedding where the client initialization would fail if no API key was available during instantiation. The fix moves client initialization to the `_initialize_by_component_configer` method, aligning with the architecture pattern used by other embedding implementations such as DoubaoEmbedding.

## Features
- Moved client initialization from `__init__` to `_initialize_by_component_configer`
- Added lazy client initialization in `get_embeddings` method when needed
- Improved error handling with clear error messages
- Made the embedding class more robust when API key is missing or invalid

## Technical Details
- Follows the config-driven initialization pattern used by other agent templates
- Implements proper validation for API key before attempting to create client
- Provides graceful error handling with descriptive error messages
- Ensures consistent behavior across embedding implementations
- Maintains interface compatibility with the base Embedding class

## Implementation Changes
- Removed client initialization from `__init__` method
- Added `_initialize_by_component_configer` implementation to handle configuration-based initialization
- Enhanced `get_embeddings` method to check for client existence and initialize if needed
- Added proper error handling for cases where API key is unavailable

## Checklist
- [✅] Code follows project's coding style
- [✅] Implementation aligns with existing architecture patterns
- [✅] Proper error handling implemented
- [✅] Maintains backward compatibility
- [✅] Fix addresses the root cause of the issue